### PR TITLE
Fix content script host permission and layout checker.

### DIFF
--- a/src/content_script/utils/checker.ts
+++ b/src/content_script/utils/checker.ts
@@ -17,7 +17,12 @@ export const isTweetDeck = (): boolean => getHost() === 'tweetdeck.twitter.com'
  */
 export const isTwitter = (): boolean => {
   const host = getHost()
-  return host === 'twitter.com' || host === 'mobile.twitter.com'
+  return (
+    host === 'twitter.com' ||
+    host === 'mobile.twitter.com' ||
+    host === 'x.com' ||
+    host === 'mobile.x.com'
+  )
 }
 
 const ComposeTweetRegEx = /\/compose\/tweet\/?.*/

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -35,7 +35,8 @@
         "*://twitter.com/*",
         "*://mobile.twitter.com/*",
         "*://tweetdeck.twitter.com/*",
-        "*://x.com/*"
+        "*://x.com/*",
+        "*://mobile.x.com/*"
       ],
       "js": [
         "main.js"

--- a/src/manifest_firefox.json
+++ b/src/manifest_firefox.json
@@ -35,7 +35,9 @@
       "matches": [
         "*://twitter.com/*",
         "*://mobile.twitter.com/*",
-        "*://tweetdeck.twitter.com/*"
+        "*://tweetdeck.twitter.com/*",
+        "*://x.com/*",
+        "*://mobile.x.com/*"
       ],
       "js": [
         "main.js"

--- a/src/manifest_firefox_v3.json
+++ b/src/manifest_firefox_v3.json
@@ -36,7 +36,8 @@
         "*://twitter.com/*",
         "*://mobile.twitter.com/*",
         "*://tweetdeck.twitter.com/*",
-        "*://x.com/*"
+        "*://x.com/*",
+        "*://mobile.x.com/*"
       ],
       "js": [
         "main.js"


### PR DESCRIPTION
The observer select don't know how to deal with `x.com` host then return the default legacy deck observer.

Fix #146 