### PR TITLE
fix: fix video thumbnail download issue.

### DIFF
--- a/src/backend/downloads/MediaDownloader.ts
+++ b/src/backend/downloads/MediaDownloader.ts
@@ -54,15 +54,15 @@ export default class MediaDownloader {
       Array.from(mediaCatalog.videos).filter(isValidTweetMediaFileUrl).forEach(download)
 
       Array.from(mediaCatalog.images)
-        .filter(isValidTweetMediaFileUrl)
+        .filter(({ url }) => isValidTweetMediaFileUrl(url))
         .filter(shouldAllowThumbnail(this.featureSettings.includeVideoThumbnail))
-        .forEach(download)
+        .forEach(({ url }, index) => download(url, index))
     }
   }
 }
 
 const shouldAllowThumbnail = (allow: boolean) =>
-  allow ? () => true : (url: string) => !url.includes('video_thumb')
+  allow ? () => true : (image: TweetImage) => image._type === 'normal'
 
 const buildFilePathMaker =
   (filenameUsecase: V4FilenameSettingsUsecase) =>

--- a/src/backend/downloads/useCases/downloadActionUseCase.ts
+++ b/src/backend/downloads/useCases/downloadActionUseCase.ts
@@ -141,7 +141,7 @@ const makeDownloadHistoryItem =
       tweetTime: tweetDetail.createdAt,
       downloadTime: new Date(),
       mediaType: parseMediaTypeFromMediaCatalog(catalog),
-      thumbnail: catalog.images.at(0),
+      thumbnail: catalog.images.at(0).url,
       userId: tweetDetail.userId,
     })
 

--- a/src/backend/twitterApi/useCases.ts
+++ b/src/backend/twitterApi/useCases.ts
@@ -344,7 +344,11 @@ export class MediaTweetUseCases {
 
     if (medias !== undefined) {
       mediaCatalog = medias.reduce((catalog, media) => {
-        catalog.images.push(cleanUrl(media.media_url_https))
+        const image: TweetImage = {
+          url: cleanUrl(media.media_url_https),
+          _type: 'video_info' in media ? 'thumbnail' : 'normal',
+        }
+        catalog.images.push(image)
         media?.video_info && catalog.videos.push(getBestQualityVideoUrl(media.video_info))
         return catalog
       }, mediaCatalog)

--- a/src/test/unit_test/backend/download/MediaDownload.test.ts
+++ b/src/test/unit_test/backend/download/MediaDownload.test.ts
@@ -91,9 +91,12 @@ describe('MediaDownloader Unit Test', () => {
 
   const mediaCatalog: TweetMediaCatalog = {
     images: [
-      'https://pbs.twimg.com/ext_tw_video_thumb/123/pu/img/THUMBNAIL.jpg',
-      'https://pbs.twimg.com/media/IMAGE.jpg',
-      'https://pbs.twimg.com/media/IMAGE.jpg',
+      {
+        url: 'https://pbs.twimg.com/ext_tw_video_thumb/123/pu/img/THUMBNAIL.jpg',
+        _type: 'thumbnail',
+      },
+      { url: 'https://pbs.twimg.com/media/IMAGE.jpg', _type: 'normal' },
+      { url: 'https://pbs.twimg.com/media/IMAGE.jpg', _type: 'normal' },
     ],
     videos: ['https://video.twimg.com/ext_tw_video/123/pu/vid/1280x720/video.mp4'],
   }

--- a/src/types/harvest.d.ts
+++ b/src/types/harvest.d.ts
@@ -11,8 +11,13 @@ type TweetInfo = {
   tweetId: string
 }
 
+type TweetImage = {
+  _type: 'normal' | 'thumbnail'
+  url: string
+}
+
 type TweetMediaCatalog = {
-  images: string[]
+  images: TweetImage[]
   videos: string[]
 }
 


### PR DESCRIPTION
Not all of thumbnails have path which includes `video_thumb`.
Instead of guessing type from the url, check the media has `video_info` or not and set the image type explictly.