### PR TITLE
feat(contentScript): support anonymous mode parsing

### DIFF
--- a/src/contentScript/core/Harvester.test.ts
+++ b/src/contentScript/core/Harvester.test.ts
@@ -1,9 +1,9 @@
 /**
  * @jest-environment jsdom
  */
+import { isSuccessResult } from '#utils/result'
 import { makeHarvestButton } from './Harvester'
 import { screen } from '@testing-library/dom'
-import * as IOE from 'fp-ts/lib/IOEither'
 import { pipe } from 'fp-ts/lib/function'
 import fs from 'fs/promises'
 import sysPath from 'path'
@@ -113,16 +113,9 @@ describe.each([
       .spyOn(runtime, 'sendMessage')
       .mockResolvedValue({ status: 'ok', payload: { isExist: true } })
 
-    const result = pipe(
-      getArticle(),
-      makeHarvestButton,
-      IOE.match(
-        () => 'bad',
-        () => 'ok'
-      )
-    )()
+    const result = pipe(getArticle(), makeHarvestButton)()
 
-    expect(result).toBe('ok')
+    expect(isSuccessResult(result))
 
     const harvesterButton = screen.queryByTestId('harvester-button')
     expect(harvesterButton).toBeInTheDocument()

--- a/src/contentScript/core/Harvester.ts
+++ b/src/contentScript/core/Harvester.ts
@@ -4,23 +4,33 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 import downloadButtonSVG from '#assets/icons/twitter-download.svg'
+import { toErrorResult, toSuccessResult } from '#utils/result'
 import { selectArtcleMode } from '../utils/article'
 import { checkButtonStatus, makeButtonListener } from '../utils/button'
+import { isAnonymousMode } from '../utils/checker'
 import { createElementFromHTML } from '../utils/helper'
 import * as E from 'fp-ts/Either'
 import * as IOE from 'fp-ts/IOEither'
 import { flow, pipe } from 'fp-ts/function'
 import { $ } from 'select-dom'
 
-const removeButtonStatsText = (btnContainer: HTMLElement) =>
-  $(
-    '[data-testid="app-text-transition-container"] > span > span',
-    btnContainer
-  )?.remove()
+const removeButtonStatsText = (btnContainer: HTMLElement) => {
+  if (isAnonymousMode()) {
+    const buttoneElement = $('[aria-label="Reply', btnContainer)
+    buttoneElement?.nextElementSibling?.remove()
+    buttoneElement?.removeAttribute('aria-label')
+  } else {
+    $(
+      '[data-testid="app-text-transition-container"] > span > span',
+      btnContainer
+    )?.remove()
+  }
+}
 
 const bleachButton = <T extends HTMLElement>(sampleButton: T) => {
   const emptyButton = sampleButton.cloneNode(true) as T
   removeButtonStatsText(emptyButton)
+
   return emptyButton
 }
 
@@ -45,14 +55,19 @@ const richIconSibling =
 
 const getActionBar = (article: HTMLElement) =>
   pipe(
-    $('[role="group"][aria-label]', article) ||
-      $('.r-18u37iz[role="group"][id^="id__"]', article),
+    isAnonymousMode()
+      ? $('.\\@container', article) ||
+          $('button[type="button"][aria-label="Reply"]', article)?.parentElement
+            ?.parentElement?.parentElement
+      : $('[role="group"][aria-label]', article) ||
+          $('.r-18u37iz[role="group"][id^="id__"]', article), // FIXME: Rely on magic class name
     E.fromNullable('Failed to get action bar.')
   )
 
 const getSampleButton = (article: HTMLElement) =>
   pipe(
-    $('[data-testid="reply"] > div', article),
+    $('[data-testid="reply"] > div', article) ||
+      $('[aria-label="Reply"]', article)?.closest('div'), // For anonymous mode
     E.fromNullable('Failed to get sample button')
   )
 
@@ -83,7 +98,10 @@ export const makeHarvestButton = (article: HTMLElement) =>
     ),
     IOE.tap(ctx => pipe(ctx.actionBar.appendChild(ctx.button), IOE.of)),
     IOE.tap(ctx => pipe(checkButtonStatus(ctx.button), IOE.of)),
-    IOE.map(() => 'ok')
+    IOE.match(
+      e => toErrorResult(new Error(e)),
+      () => toSuccessResult('ok')
+    )
   )
 
 const wrapButton = (mode: TweetMode) => (button: HTMLElement) =>

--- a/src/contentScript/core/index.ts
+++ b/src/contentScript/core/index.ts
@@ -3,31 +3,31 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-import { isArticleCanBeAppend, isArticlePhotoMode } from '../utils/article'
-import { findButton, setTargetArticle } from '../utils/article'
+import { getError, isErrorResult } from '#utils/result'
+import {
+  canArticleBeAppended,
+  findButton,
+  isArticlePhotoMode,
+  setTargetArticle,
+} from '../utils/article'
 import { checkButtonStatus } from '../utils/button'
 import { isFunctionablePath } from '../utils/checker'
 import { makeHarvestButton } from './Harvester'
 import { pipe } from 'fp-ts/lib/function'
 
 const makeHarvester = (article: HTMLElement) => {
-  if (isArticlePhotoMode(article) && !isArticleCanBeAppend(article)) {
+  /**
+   * The button in photo mode will not be changed with post changing, so the
+   * status need to be checked manually
+   */
+  if (isArticlePhotoMode(article) && !canArticleBeAppended(article)) {
     const button = findButton(article)
     if (button) checkButtonStatus(button)
   }
 
-  if (isFunctionablePath() && isArticleCanBeAppend(article)) {
-    const makeButton = makeHarvestButton
-    const task = pipe(
-      article,
-      setTargetArticle,
-      makeButton
-      // IOE.tapError(e => {
-      //   /** TODO: Handle error */
-      // })
-    )
-
-    task()
+  if (isFunctionablePath() && canArticleBeAppended(article)) {
+    const result = pipe(article, setTargetArticle, makeHarvestButton)()
+    if (__DEV__ && isErrorResult(result)) console.error(getError(result))
   }
 }
 

--- a/src/contentScript/observers/TwitterMediaObserver.ts
+++ b/src/contentScript/observers/TwitterMediaObserver.ts
@@ -5,7 +5,11 @@
  */
 import makeHarvester from '../core'
 import { articleHasMedia } from '../utils/article'
-import { isInTweetStatus, isStreamLoaded } from '../utils/checker'
+import {
+  isAnonymousMode,
+  isInTweetStatus,
+  isStreamLoaded,
+} from '../utils/checker'
 import { revealNsfw } from '../utils/helper'
 import observeElement from './observer'
 import { $, $$ } from 'select-dom'
@@ -23,6 +27,13 @@ const enum Query {
 export default class TwitterMediaObserver implements IHarvestObserver {
   constructor(readonly autoRevealNsfw = false) {}
 
+  observeAll() {
+    this.observeHead()
+    this.observeModal()
+    this.observeStream()
+    this.observeHead()
+  }
+
   observeRoot() {
     const options: MutationObserverInit = {
       childList: true,
@@ -30,16 +41,23 @@ export default class TwitterMediaObserver implements IHarvestObserver {
     }
 
     const rootMutationCallback: MutationCallback = (_, observer) => {
+      if (__DEV__) console.info('root mutation')
+
       this.initialize()
       if (isStreamLoaded()) {
-        this.observeHead()
-        this.observeModal()
-        this.observeStream()
-        this.observeHead()
+        this.observeAll()
         observer.disconnect()
       }
     }
-    observeElement('Root', Query.Root, rootMutationCallback, options)
+
+    const root = isAnonymousMode()
+      ? $('.contents [itemscope] [itemtype$="ProfilePage"]')
+      : $(Query.Root) // For anonymous mode
+    if (root) observeElement('Root', root, rootMutationCallback, options)
+    if (!root) {
+      this.initialize()
+      this.observeAll()
+    }
   }
 
   initialize() {
@@ -75,7 +93,10 @@ export default class TwitterMediaObserver implements IHarvestObserver {
       }
     }
 
-    observeElement('Stream', Query.Stream, mutaionCb)
+    const streamContainer = isAnonymousMode()
+      ? $('article')?.closest('ul')
+      : $(Query.Stream)
+    if (streamContainer) observeElement('Stream', streamContainer, mutaionCb)
   }
 
   observeTimeline() {

--- a/src/contentScript/observers/observer.ts
+++ b/src/contentScript/observers/observer.ts
@@ -37,6 +37,7 @@ export const observeElement = (
     const observer = new MutationObserver(observerCallback)
     observer.observe(observedElement, options)
     setObserverId(observeId)(observedElement)
+    if (__DEV__) console.info(`[MH:ContentScript] Observe (id: ${observeId})`)
     return observer
   }
 

--- a/src/contentScript/utils/article.ts
+++ b/src/contentScript/utils/article.ts
@@ -5,7 +5,7 @@
  */
 import { TweetInfo } from '#domain/valueObjects/tweetInfo'
 import { toErrorResult, toSuccessResult } from '#utils/result'
-import { isInTweetStatus } from './checker'
+import { isAnonymousMode, isInTweetStatus } from './checker'
 import * as A from 'fp-ts/Array'
 import * as E from 'fp-ts/Either'
 import { fromPredicate as optionFromPredicate } from 'fp-ts/lib/Option'
@@ -131,7 +131,7 @@ export const findButton = (article: HTMLElement): HTMLElement | undefined =>
 export const articleHasMedia = (article: HTMLElement) =>
   article && (articleHasVideo(article) || aricleHasPhoto(article))
 
-export const isArticleCanBeAppend = (article: HTMLElement) =>
+export const canArticleBeAppended = (article: HTMLElement) =>
   !(
     elementExists('.deck-harvester', article) ||
     elementExists('.harvester', article)
@@ -187,11 +187,22 @@ export const getLinksFromArticle = (article: HTMLElement): string[] => {
   const timeEle = $('a > time', article)
   if (timeEle?.parentElement?.tagName === 'A')
     anchorEles.push(timeEle.parentElement)
-  return anchorEles
-    .filter(e => e.hasAttribute('href'))
-    .map(e => e.getAttribute('href'))
-    .filter(isString)
-    .map(path => path.replace(featureRegEx.editedHistoryUrl, ''))
+
+  if (anchorEles.length > 0)
+    return anchorEles
+      .filter(e => e.hasAttribute('href'))
+      .map(e => e.getAttribute('href'))
+      .filter(href => href !== null)
+      .map(path => path.replace(featureRegEx.editedHistoryUrl, ''))
+
+  // Use meta element to parse link of tweet.
+  if (isAnonymousMode()) {
+    const urlMeta = $('meta[itemprop="url"]', article)
+    if (urlMeta)
+      return [urlMeta.content.replace(featureRegEx.editedHistoryUrl, '')]
+  }
+
+  return []
 }
 
 export const getTweetIdFromLink = (link: string) =>

--- a/src/contentScript/utils/checker.test.ts
+++ b/src/contentScript/utils/checker.test.ts
@@ -2,6 +2,7 @@
  * @jest-environment <rootDir>/jest.environment.ts
  */
 import {
+  isAnonymousMode,
   isBetaTweetDeck,
   isBusinessRelatedTweet,
   isComposingTweet,
@@ -24,6 +25,8 @@ const setHost = (host: string) => setJSDOMURL(`http://${host}`)
 
 const setPath = (path: string) => history.replaceState(null, '', path)
 
+beforeEach(() => mockExists.mockReset())
+
 describe('isStreamLoaded', () => {
   it('should return true if both role="region" and article exist', () => {
     mockExists.mockReturnValueOnce(true).mockReturnValueOnce(true)
@@ -31,7 +34,7 @@ describe('isStreamLoaded', () => {
   })
 
   it('should return false if either role="region" or article does not exist', () => {
-    mockExists.mockReturnValueOnce(false)
+    mockExists.mockReturnValue(false)
     expect(isStreamLoaded()).toBe(false)
   })
 })
@@ -139,6 +142,18 @@ describe('isBusinessRelatedTweet', () => {
     const element = document.createElement('div')
     mockExists.mockReturnValueOnce(false)
     expect(isBusinessRelatedTweet(element)).toBe(false)
+  })
+})
+
+describe('isAnonymousMode', () => {
+  it('should return true if an article has a meta child element', () => {
+    mockExists.mockReturnValueOnce(true)
+    expect(isAnonymousMode()).toBe(true)
+  })
+
+  it('should return false if no article has a meta child element', () => {
+    mockExists.mockReturnValueOnce(false)
+    expect(isAnonymousMode()).toBe(false)
   })
 })
 

--- a/src/contentScript/utils/checker.ts
+++ b/src/contentScript/utils/checker.ts
@@ -6,7 +6,9 @@
 import { elementExists } from 'select-dom'
 
 export const isStreamLoaded = () =>
-  elementExists('[role="region"]') && elementExists('article')
+  isAnonymousMode()
+    ? elementExists('meta[content="Profile posts"] article')
+    : elementExists('[role="region"]') && elementExists('article')
 
 const getHost = (): string => window.location.host
 
@@ -53,6 +55,8 @@ export const isInTweetStatus = (): boolean =>
 
 export const isBetaTweetDeck = (): boolean =>
   isTweetDeck() && elementExists('#react-root')
+
+export const isAnonymousMode = (): boolean => elementExists('article meta')
 
 export const isBusinessRelatedTweet = (ele: HTMLElement): boolean =>
   elementExists('[data-testid="placementTracking"]', ele) ||


### PR DESCRIPTION
Anonymous (logged-out) X pages render articles with <meta> children and a different action-bar structure. Detect that layout via isAnonymousMode and branch the observers, action-bar lookup, sample button, and link parsing accordingly.

- add isAnonymousMode checker + test
- parse tweet link from meta[itemprop="url"] when no anchors exist
- observe ProfilePage root / article list in anonymous mode
- return Result from makeHarvestButton and log errors in dev
- rename isArticleCanBeAppend -> canArticleBeAppended